### PR TITLE
Allow CORS from all sources

### DIFF
--- a/filmsuggester/settings.py
+++ b/filmsuggester/settings.py
@@ -37,11 +37,13 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'corsheaders'
 ]
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -118,3 +120,8 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.1/howto/static-files/
 
 STATIC_URL = '/static/'
+
+# To allow CORS for react. This makes everything accessible, would want
+# to restrict this if we productionised. https://stackoverflow.com/questions/44037474/cors-error-while-consuming-calling-rest-api-with-react
+CORS_ORIGIN_ALLOW_ALL = True
+ALLOWED_HOSTS = ['*']


### PR DESCRIPTION
This PR relates to [this card](https://trello.com/c/vFmjRMPP/10-backend-allow-cors-access-from-frontend-origin) and allows CORS from all sources. 

After this PR you can make a request to any endpoint and not have a CORS error. 

Per note in the code, this allows CORS from all sources - we would want to restrict that if we productionized (see [this stack](https://stackoverflow.com/a/62458772/5615805) on how). 

Sign offs:
- [x] George 